### PR TITLE
Alpine versions removed from development images.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   mclojure:
-    image: clojure:lein-2.8.1-alpine
+    image: clojure:lein-2.8.1
     hostname: mclojure
     container_name: mclojure
     working_dir: /app
@@ -20,7 +20,7 @@ services:
       - MEASURE_DB_USER=muser
       - MEASURE_DB_PASSWORD=mpassword
   mnode:
-    image: node:9.9.0-alpine
+    image: node:9.9.0
     hostname: mnode
     entrypoint: ./node-entrypoint.sh
     container_name: mnode
@@ -37,7 +37,7 @@ services:
     links:
       - mclojure
   mpostgres:
-    image: postgres:10.3-alpine
+    image: postgres:10.3
     hostname: mpostgres
     container_name: mpostgres
     environment:


### PR DESCRIPTION
We wanna have the possibility to access `bash` within the containers